### PR TITLE
correct mod path for linux

### DIFF
--- a/Assets/Editor/Utility/Utility.cs
+++ b/Assets/Editor/Utility/Utility.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using UnityEditor;
 using UnityEngine;
@@ -22,7 +23,7 @@ namespace ParkitectAssetEditor.Utility {
 #elif UNITY_STANDALONE_WIN
 				return System.IO.Path.GetFullPath(System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments) + "/Parkitect/", "Mods"));
 #else
-				return System.IO.Path.GetFullPath(System.IO.Path.Combine(Application.dataPath + "/..", "Mods"));
+                return Path.GetFullPath(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Personal),".steam/steam/steamapps/common/Parkitect/Mods"));
 #endif
             }
         }


### PR DESCRIPTION
I would ideally like the mod path for linux to be "~/.parkitect/mod/<your-mod>". somewhere relative to the user path since you can have steam install to a different directory but most people don't change this at all. For the general usecase this is not too bad from my perspective. 